### PR TITLE
feat: add retain: true to mealie persistence

### DIFF
--- a/kubernetes/apps/home/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mealie/app/helmrelease.yaml
@@ -100,5 +100,6 @@ spec:
         storageClass: nfs-client
         accessMode: ReadWriteOnce
         size: 5Gi
+        retain: true
         globalMounts:
           - path: /app/data


### PR DESCRIPTION
Ensures mealie PVC is retained when the HelmRelease is deleted.