### PR TITLE
feat: use longhorn storage for postgres cluster

### DIFF
--- a/kubernetes/apps/db/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/db/cloudnative-pg/cluster/cluster.yaml
@@ -19,7 +19,7 @@ spec:
                   - amd64
   storage:
     size: 100Gi
-    storageClass: nfs-client
+    storageClass: longhorn
   superuserSecret:
     name: postgres-superuser
   enableSuperuserAccess: true


### PR DESCRIPTION
NFS is not recommended for PostgreSQL due to:
- fsync/write ordering issues that can lead to data corruption
- Performance problems (network latency on every disk operation)  
- File locking issues with WAL files

Longhorn provides better reliability and performance for database workloads.

**Note:** The existing postgres PVC on NFS will need to be deleted for this to take effect (data will be archived due to archiveOnDelete).