### PR TITLE
feat: add clawdbot deployment to agents namespace

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clawdbot
+  namespace: agents
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.2.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      clawdbot:
+        containers:
+          clawdbot:
+            image:
+              repository: craighton/clawdbot-k8s
+              tag: latest
+            env:
+              HOME: /home/node
+              TERM: xterm-256color
+              TZ: America/Denver
+              CLAWDBOT_GATEWAY_BIND: lan
+              CLAWDBOT_GATEWAY_PORT: "18789"
+            envFrom:
+              - secretRef:
+                  name: clawdbot-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 18789
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            command:
+              - node
+              - dist/index.js
+              - gateway-daemon
+              - --bind
+              - lan
+              - --port
+              - "18789"
+
+    service:
+      clawdbot:
+        controller: clawdbot
+        ports:
+          http:
+            port: *port
+
+    persistence:
+      config:
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: nfs-client
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        retain: true
+        globalMounts:
+          - path: /home/node/.clawdbot
+      workspace:
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: nfs-client
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        retain: true
+        globalMounts:
+          - path: /home/node/clawd

--- a/kubernetes/apps/agents/clawdbot/app/kustomization.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml

--- a/kubernetes/apps/agents/clawdbot/app/secret.sops.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/secret.sops.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: clawdbot-secret
+    namespace: agents
+type: Opaque
+stringData:
+    CLAWDBOT_GATEWAY_TOKEN: ENC[AES256_GCM,data:XAOMhRlKpsTFF4s8bWQKM+yL/5mt8jUHgUo7LsYnohk=,iv:c4dnrZ6txmDEW3KfIaXDI/joQ/RwCvUmX2dPpn74J38=,tag:KCELdSHngfHHUAQoPLdaLw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age16ruxdp45mj6tc80n6fu3x5xvqccl963ms8qln8sah6plxyvcj47st7u2yf
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTa0VZSXlzK0pzLzR6UGYw
+            dTFHOVlnT3RkSUNZUTBPd0tZdkgzc1NvYkNBClhTeUc5TkxwcU9FOWRQeXQ0Ukhk
+            dHdxcjl6S0Y4ZjkrSkVhbFh6VFpjU28KLS0tIE9SMnpiS0dqQU1Zd3FMd3Y2akZL
+            VjZBamtRbnFWUk5vd3lDb2crcE0xTE0Kdgs+W1iOPAV6DcWL/ZKcu1RiFgiTRm33
+            MMb/dPahOR/Wi7QD/mqqppZXRaUVm4bHujXE5Zv8cgMm/T6CyN7LIA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-01-23T01:25:38Z"
+    mac: ENC[AES256_GCM,data:qMAifu2OZ6b2TgBjIbk9A8vESS54PPbU0rI6JmFtnWpvhQwHLTHONiHMEYgyuTjCVk5hkoucj1KKUu7pHRxAFdoU/uofti4fgPlwxV7VBGsKOvFEJwUUIeJJH4OM/Wf1+a2n43+KApsW9RMQgELilscjJGDfUzxmrZlmWzaJadQ=,iv:Rgp6jUz2hHMgWnB9NhRNNgGS8DINJdDCcOBS2h7j970=,tag:oae+gZeA83O8370u6hSkMA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/kubernetes/apps/agents/clawdbot/ks.yaml
+++ b/kubernetes/apps/agents/clawdbot/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app clawdbot
+  namespace: flux-system
+spec:
+  targetNamespace: agents
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/agents/clawdbot/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/agents/kustomization.yaml
+++ b/kubernetes/apps/agents/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./clawdbot/ks.yaml

--- a/kubernetes/apps/agents/namespace.yaml
+++ b/kubernetes/apps/agents/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agents


### PR DESCRIPTION
Deploys Clawdbot gateway to Kubernetes cluster.

## What's included:
- New `agents` namespace
- Clawdbot gateway deployment using `craighton/clawdbot-k8s:latest` (multi-arch)
- NFS persistent storage:
  - `config` (1Gi) → `/home/node/.clawdbot`
  - `workspace` (10Gi) → `/home/node/clawd`
- Gateway token secret (SOPS encrypted)
- Service on port 18789

## Post-merge:
The gateway will start but won't be fully functional until configured. You may need to:
1. Copy existing config to the PVC, or
2. Run initial setup via exec into the pod

Gateway token for this deployment: stored in `clawdbot-secret`