### PR TITLE
feat(clawdbot): add Discord and Anthropic secrets, enable configured mode

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -76,7 +76,6 @@ spec:
               - "18789"
               - --bind
               - lan
-              - --allow-unconfigured
 
     service:
       clawdbot:

--- a/kubernetes/apps/agents/clawdbot/app/secret.sops.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/secret.sops.yaml
@@ -5,7 +5,9 @@ metadata:
     namespace: agents
 type: Opaque
 stringData:
-    CLAWDBOT_GATEWAY_TOKEN: ENC[AES256_GCM,data:XAOMhRlKpsTFF4s8bWQKM+yL/5mt8jUHgUo7LsYnohk=,iv:c4dnrZ6txmDEW3KfIaXDI/joQ/RwCvUmX2dPpn74J38=,tag:KCELdSHngfHHUAQoPLdaLw==,type:str]
+    CLAWDBOT_GATEWAY_TOKEN: ENC[AES256_GCM,data:j3GUnaHm8uYP/sU26CA5uW9bnWBIFPFZv+Kf/GZ1ys0=,iv:yFxlCGmggUvDzlHI3prYm5mp49dVHthIh7DFnh2aA90=,tag:rdx0C4V7+0+Oe8CMIjBGZg==,type:str]
+    DISCORD_TOKEN: ENC[AES256_GCM,data:zmKsWYS/bZLqMTAFtHsaVjK6k7cRG43OS0gQunODTXDO95tCoG1d+TfZLEmxSw+tadmOp7/PCw0iAfXbpSZ22W8SFWhSDc2S,iv:Vq4iv5pRhVl9GtvCDxBej1I/58ODCJ7ZvbQhBBrPF/A=,tag:7BinDmfmgO/yw+JagMQeLQ==,type:str]
+    ANTHROPIC_API_KEY: ENC[AES256_GCM,data:XhjKHP5+YgZn3bRpn3g0ODRcgX7l9P4m1SGqcNHaXiKVkIITrbPJ1ktxe4/NHx3Uc4qzY3fokhQEOxbJ9rHsYX7OOTllKqTiYqumTNcmX5RUKeTgb7nRoU+aREfWAcCl0tYx8W/tLRqxCynP,iv:evtEnSmpTPscUKMG6WEDAxq1FqQ4W5/C+I9TV6epBSM=,tag:ihq7nD1f87wuooBdHgH8wA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -15,14 +17,14 @@ sops:
         - recipient: age16ruxdp45mj6tc80n6fu3x5xvqccl963ms8qln8sah6plxyvcj47st7u2yf
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTa0VZSXlzK0pzLzR6UGYw
-            dTFHOVlnT3RkSUNZUTBPd0tZdkgzc1NvYkNBClhTeUc5TkxwcU9FOWRQeXQ0Ukhk
-            dHdxcjl6S0Y4ZjkrSkVhbFh6VFpjU28KLS0tIE9SMnpiS0dqQU1Zd3FMd3Y2akZL
-            VjZBamtRbnFWUk5vd3lDb2crcE0xTE0Kdgs+W1iOPAV6DcWL/ZKcu1RiFgiTRm33
-            MMb/dPahOR/Wi7QD/mqqppZXRaUVm4bHujXE5Zv8cgMm/T6CyN7LIA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPSU4zZnI3RjdXdFVMd2Z4
+            aHpaTXhKOGJmdzVxMEtIS2EveGpjRHFYaW5FCng2VlN1UjIrU0tOMllCbEZ5RzFi
+            QzREMjI0UUxQaE8vRVZhSkpFYW9DN00KLS0tIG11SkE4elhFLzZvbk45dWRZb1Ix
+            ekxOQ0xNeUk4V05KRkxTT3FKUWpqMmMKjEikt47t7FfWt8/WPlmtkHhGvJ7/S6T1
+            5AifYt7eqH2DuOrYnvB2b+pYQgNtKR7k5ECVX9byH98kca/VAaTlQw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-01-23T01:25:38Z"
-    mac: ENC[AES256_GCM,data:qMAifu2OZ6b2TgBjIbk9A8vESS54PPbU0rI6JmFtnWpvhQwHLTHONiHMEYgyuTjCVk5hkoucj1KKUu7pHRxAFdoU/uofti4fgPlwxV7VBGsKOvFEJwUUIeJJH4OM/Wf1+a2n43+KApsW9RMQgELilscjJGDfUzxmrZlmWzaJadQ=,iv:Rgp6jUz2hHMgWnB9NhRNNgGS8DINJdDCcOBS2h7j970=,tag:oae+gZeA83O8370u6hSkMA==,type:str]
+    lastmodified: "2026-01-23T03:41:51Z"
+    mac: ENC[AES256_GCM,data:gs0zRth6ksGq1A4Uuv4d00IE+BcZPeHLQZ+TSCJxVnzLCHSabijXLHks1HlntlKX9r1LOKGmzGhtbmpo8e9md8dJponC0T5ThoYBOI/mwRWn9oniiFiVggK3lD+OeJWCZxaSJPR1mYk5i6f/KdeRTOUObg+yxjyP0UavP9Vj1KY=,iv:ss7pxvBnIVc+u2Nb3aUMkMbKsU50GaybU+6MBbrMmxM=,tag:JfEGUqnHM1PrSn8PjJgQGw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.8.1


### PR DESCRIPTION
## Changes

- Add `DISCORD_TOKEN` and `ANTHROPIC_API_KEY` to clawdbot-secret (sops encrypted)
- Remove `--allow-unconfigured` flag from gateway command

## Context

The clawdbot config directory on NAS now has `clawdbot.json` with workspace path and Discord guild config. This PR adds the missing secrets so the bot can authenticate with Discord and Claude API.

## Volumes
- `agents-clawdbot-config` → `/home/node/.clawdbot` (has clawdbot.json)
- `agents-clawdbot-workspace` → `/home/node/clawd` (has agent workspace files)