### PR TITLE
fix(clawdbot): use gateway-daemon for container mode

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -71,7 +71,7 @@ spec:
             command:
               - node
               - dist/index.js
-              - gateway
+              - gateway-daemon
               - --port
               - "18789"
               - --bind


### PR DESCRIPTION
gateway-daemon runs in foreground, gateway tries to daemonize which conflicts with pid 1 in containers