### PR TITLE
feat(clawdbot): mount workspace PVC as home directory

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -104,15 +104,9 @@ spec:
             secretName: clawd-tls
 
     persistence:
-      config:
-        enabled: true
-        type: persistentVolumeClaim
-        storageClass: nfs-client
-        accessMode: ReadWriteOnce
-        size: 1Gi
-        retain: true
-        globalMounts:
-          - path: /home/node/.clawdbot
+      # Note: config PVC (clawdbot-config) is no longer needed
+      # .clawdbot data has been migrated into the workspace PVC
+      # The old PVC can be deleted after confirming stability
       workspace:
         enabled: true
         type: persistentVolumeClaim
@@ -121,4 +115,4 @@ spec:
         size: 10Gi
         retain: true
         globalMounts:
-          - path: /home/node/clawd
+          - path: /home/node


### PR DESCRIPTION
## Summary
Mount the workspace PVC to `/home/node` instead of `/home/node/clawd`, allowing all dotfiles to persist automatically.

## Changes
- Workspace PVC now mounts to `/home/node`
- Removed config PVC mount (data migrated to workspace)

## New home directory structure (on NAS)
```
/home/node/
├── .bashrc, .profile      # Shell config
├── .claude.json           # Claude Code auth
├── .claude/               # Claude Code settings
├── .local/                # Claude Code binary
├── .clawdbot/             # Clawdbot config (migrated)
└── clawd/                 # Workspace repo
```

## Migration done
- [x] Restructured NAS with dotfiles at root
- [x] Copied .clawdbot data from config PVC to workspace
- [x] Workspace path remains `/home/node/clawd`

## After merge
- Old config PVC (`clawdbot-config`) can be deleted after confirming stability