### PR TITLE
feat(clawdbot): add reloader annotation for secret changes

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -23,6 +23,10 @@ spec:
     remediation:
       retries: 3
   values:
+    defaultPodOptions:
+      annotations:
+        secret.reloader.stakater.com/reload: clawdbot-secret
+
     controllers:
       clawdbot:
         containers:


### PR DESCRIPTION
## Summary
Adds `secret.reloader.stakater.com/reload: clawdbot-secret` annotation to automatically restart clawdbot pod when the secret is updated.

## Changes
- Added `defaultPodOptions.annotations` with reloader annotation

## Why
Enables automatic restarts when Doppler secrets change, removing the need for manual pod restarts.

## Testing
- [ ] Merge and verify pod has annotation
- [ ] Update a secret value in Doppler
- [ ] Confirm pod restarts automatically