### PR TITLE
fix(clawdbot): clean up stale lock files on startup

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -74,13 +74,12 @@ spec:
               limits:
                 memory: 2Gi
             command:
-              - node
-              - dist/index.js
-              - gateway
-              - --port
-              - "18789"
-              - --bind
-              - lan
+              - /bin/sh
+              - -c
+              - |
+                # Clean up stale lock files from previous runs (NAS persistence)
+                find /home/node/.clawdbot -name '*.lock' -delete 2>/dev/null || true
+                exec node dist/index.js gateway --port 18789 --bind lan
 
     service:
       clawdbot:


### PR DESCRIPTION
## Problem
When the pod restarts, stale `.lock` files persist on NAS causing:
```
Agent failed before reply: session file locked (timeout 10000ms): pid=1 ...
```

## Solution
Add a cleanup step before starting the gateway:
```sh
find /home/node/.clawdbot -name '*.lock' -delete 2>/dev/null || true
exec node dist/index.js gateway --port 18789 --bind lan
```

## Testing
- [ ] Merge and trigger a restart
- [ ] Verify pod starts without manual lock file deletion