### PR TITLE
feat(kube-system): add external-secrets-operator with Doppler

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/app/clustersecretstore-doppler.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/clustersecretstore-doppler.yaml
@@ -1,0 +1,18 @@
+---
+# ClusterSecretStore for Doppler - home/main config
+# Requires: kubectl create secret generic doppler-token-home-main \
+#   --namespace kube-system \
+#   --from-literal dopplerToken="dp.st.xxxx"
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: doppler-home-main
+spec:
+  provider:
+    doppler:
+      auth:
+        secretRef:
+          dopplerToken:
+            name: doppler-token-home-main
+            namespace: kube-system
+            key: dopplerToken

--- a/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-secrets
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: external-secrets
+      version: 0.12.1
+      sourceRef:
+        kind: HelmRepository
+        name: external-secrets
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+    crds: Create
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  values:
+    installCRDs: true
+    serviceAccount:
+      create: true
+      name: external-secrets
+    webhook:
+      create: true
+    certController:
+      create: true

--- a/kubernetes/apps/kube-system/external-secrets/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - clustersecretstore-doppler.yaml

--- a/kubernetes/apps/kube-system/external-secrets/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/kube-system/external-secrets/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-cluster
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./spegel/ks.yaml
   - ./kubernetes-dashboard/ks.yaml
   - ./nfs-subdir-external-provisioner/ks.yaml
+  - ./external-secrets/ks.yaml

--- a/kubernetes/flux/repositories/helm/external-secrets.yaml
+++ b/kubernetes/flux/repositories/helm/external-secrets.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-secrets
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://charts.external-secrets.io

--- a/kubernetes/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/repositories/helm/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - ./longhorn.yaml
   - ./opea.yaml
   - ./otwld.yaml
+  - ./external-secrets.yaml


### PR DESCRIPTION
## Summary
Installs external-secrets-operator and configures ClusterSecretStore for Doppler.

## Components Added
- HelmRepository for external-secrets charts
- HelmRelease for external-secrets-operator v0.12.1
- ClusterSecretStore `doppler-home-main` for Doppler home/main config

## Manual Step Required (after merge)
Create a Doppler **Service Token** for the `home/main` config, then:

```bash
kubectl create secret generic doppler-token-home-main \
  --namespace kube-system \
  --from-literal dopplerToken="dp.st.xxxx"
```

## Future Work
- Migrate clawdbot-secret from SOPS to ExternalSecret
- Add more ClusterSecretStores for other Doppler configs as needed

## Testing
- [ ] Merge and wait for Flux reconcile
- [ ] Create Doppler service token + k8s secret
- [ ] Verify ClusterSecretStore is ready: `kubectl get clustersecretstores`