### PR TITLE
fix(external-secrets): correct GitRepository name

### DIFF
--- a/kubernetes/apps/kube-system/external-secrets/ks.yaml
+++ b/kubernetes/apps/kube-system/external-secrets/ks.yaml
@@ -9,7 +9,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-cluster
+    name: home-kubernetes
   interval: 30m
   retryInterval: 1m
   timeout: 5m


### PR DESCRIPTION
## Issue
Kustomization was referencing `home-cluster` but the GitRepository is actually named `home-kubernetes`.

## Fix
Changed sourceRef.name from `home-cluster` to `home-kubernetes`