### PR TITLE
fix(clawdbot): use reloader auto annotation

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -23,12 +23,10 @@ spec:
     remediation:
       retries: 3
   values:
-    defaultPodOptions:
-      annotations:
-        secret.reloader.stakater.com/reload: clawdbot-secret
-
     controllers:
       clawdbot:
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           clawdbot:
             image:


### PR DESCRIPTION
## Issue
Reloader not triggering restart on secret change.

## Fix
Switch to auto mode (same as frigate uses):

```yaml
# Old
secret.reloader.stakater.com/reload: clawdbot-secret

# New
reloader.stakater.com/auto: "true"
```

Auto mode automatically watches all referenced secrets/configmaps.