### PR TITLE
feat(clawdbot): add startup wake for proactive messaging

### DIFF
--- a/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
+++ b/kubernetes/apps/agents/clawdbot/app/helmrelease.yaml
@@ -77,6 +77,10 @@ spec:
               - |
                 # Clean up stale lock files from previous runs (NAS persistence)
                 find /home/node/.clawdbot -name '*.lock' -delete 2>/dev/null || true
+                # Run startup wake in background (triggers heartbeat after channels ready)
+                if [ -x /home/node/clawd/scripts/startup-wake.sh ]; then
+                  /home/node/clawd/scripts/startup-wake.sh &
+                fi
                 exec node dist/index.js gateway --port 18789 --bind lan
 
     service:


### PR DESCRIPTION
## Summary
Triggers `clawdbot wake` after container startup so I can proactively message after restarts.

## How it works
1. `startup-wake.sh` runs in background on container start
2. Waits for gateway health endpoint
3. Waits 5s for channels to initialize
4. Runs `clawdbot wake` to trigger immediate heartbeat

## Testing
- [ ] Merge and wait for restart
- [ ] Check logs for `[startup-wake]` messages
- [ ] Verify Clawd proactively messages (without user messaging first)