### PR TITLE
fix(mealie): add required v3 environment variables

### DIFF
--- a/kubernetes/apps/home/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mealie/app/helmrelease.yaml
@@ -38,6 +38,8 @@ spec:
               # General
               ALLOW_SIGNUP: "false"
               BASE_URL: "https://mealie.${SECRET_DOMAIN}"
+              DEFAULT_GROUP: "Home"
+              DEFAULT_HOUSEHOLD: "Family"
               # Database
               DB_ENGINE: postgres
               POSTGRES_USER: mealie


### PR DESCRIPTION
Adds DEFAULT_GROUP and DEFAULT_HOUSEHOLD environment variables required by Mealie v3.

These variables were missing and causing authentication token validation failures (401 on /api/users/self after successful login).