### PR TITLE
feat(games): Install boilerr operator v0.0.4

### DIFF
--- a/kubernetes/apps/games/boilerr/app/helmrelease.yaml
+++ b/kubernetes/apps/games/boilerr/app/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: boilerr
+  namespace: games
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: boilerr
+      version: 0.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: boilerr
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+    timeout: 15m
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Operator configuration
+    replicaCount: 1
+
+    image:
+      repository: ghcr.io/craightonh/boilerr
+      pullPolicy: IfNotPresent
+      # tag defaults to chart appVersion (0.3.0)
+
+    controllerManager:
+      logging:
+        level: info
+        development: false
+
+      metrics:
+        enabled: true
+
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+
+    # GameDefinitions configuration
+    gameDefinitions:
+      enabled: true
+      # Enable all bundled games by default
+      include: []
+      exclude: []
+
+    # CRD management
+    crds:
+      install: true
+      keep: true
+
+    # RBAC and ServiceAccount
+    rbac:
+      create: true
+    serviceAccount:
+      create: true

--- a/kubernetes/apps/games/boilerr/app/kustomization.yaml
+++ b/kubernetes/apps/games/boilerr/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/games/boilerr/ks.yaml
+++ b/kubernetes/apps/games/boilerr/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app boilerr
+  namespace: flux-system
+spec:
+  targetNamespace: games
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/games/boilerr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 15m

--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
+  - ./boilerr/ks.yaml
   - ./web-games/ks.yaml
   - ./satisfactory/ks.yaml
   # - ./icarus/ks.yaml

--- a/kubernetes/flux/repositories/helm/boilerr.yaml
+++ b/kubernetes/flux/repositories/helm/boilerr.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: boilerr
+  namespace: flux-system
+spec:
+  interval: 30m
+  url: https://craightonh.github.io/boilerr

--- a/kubernetes/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/repositories/helm/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./bjw-s.yaml
+  - ./boilerr.yaml
   - ./cloudnative-pg.yaml
   - ./cilium.yaml
   - ./coredns.yaml


### PR DESCRIPTION
## Summary
Installs the boilerr Kubernetes operator for managing Steam dedicated game servers.

## Changes
- Added boilerr Helm repository (GitHub Pages at https://craightonh.github.io/boilerr)
- Deployed boilerr operator to the `games` namespace
- Chart version: 0.3.0 (corresponds to git tag v0.0.4)
- Operator image: `ghcr.io/craightonh/boilerr:0.3.0`

## Configuration
- Enabled all bundled GameDefinitions by default
- CRDs will be installed and retained on uninstall
- Resource limits: 500m CPU / 128Mi memory
- Resource requests: 10m CPU / 64Mi memory
- Metrics enabled on port 8443

## Deployment
After merge, Flux will reconcile within 30 minutes. To apply immediately:
```bash
flux reconcile kustomization flux-repositories
flux reconcile kustomization games
```

## Verification
Check operator status:
```bash
kubectl -n games get pods -l app.kubernetes.io/name=boilerr
kubectl -n games logs -l app.kubernetes.io/name=boilerr
```