### PR TITLE
feat(boilerr): Bump to version 0.0.4

### DIFF
--- a/kubernetes/apps/games/boilerr/app/helmrelease.yaml
+++ b/kubernetes/apps/games/boilerr/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: boilerr
-      version: 0.3.0
+      version: 0.0.4
       sourceRef:
         kind: HelmRepository
         name: boilerr
@@ -29,7 +29,7 @@ spec:
     image:
       repository: ghcr.io/craightonh/boilerr
       pullPolicy: IfNotPresent
-      # tag defaults to chart appVersion (0.3.0)
+      # tag defaults to chart appVersion (0.0.4)
 
     controllerManager:
       logging:


### PR DESCRIPTION
## Summary
Updates boilerr operator from chart version 0.3.0 to 0.0.4.

## Changes
- Chart version: 0.3.0 → 0.0.4
- App version: 0.3.0 → 0.0.4
- Image: `ghcr.io/craightonh/boilerr:0.0.4`

## Context
Fixed versioning in boilerr repo so git tags now match both chart and app versions (v0.0.4 → chart 0.0.4 + app 0.0.4).

## Prerequisites
⚠️ **Before merging**, clean up old boilerr resources that lack Helm ownership labels:

```bash
# Requires cluster admin permissions
kubectl delete clusterrole boilerr-manager-role
kubectl delete clusterrolebinding boilerr-manager-rolebinding
kubectl delete crd gamedefinitions.boilerr.dev steamservers.boilerr.dev
```

## Deployment
After cleanup and merge:
```bash
flux reconcile helmrelease -n games boilerr
```

## Verification
```bash
kubectl -n games get helmrelease boilerr
kubectl -n games get pods -l app.kubernetes.io/name=boilerr
kubectl -n games logs -l app.kubernetes.io/name=boilerr
```