### PR TITLE
feat(games): Deploy Factorio server

### DIFF
--- a/kubernetes/apps/games/factorio/app/helmrelease.yaml
+++ b/kubernetes/apps/games/factorio/app/helmrelease.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: factorio
+  namespace: games
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: game-server
+      version: "1.0.1"
+      sourceRef:
+        kind: HelmRepository
+        name: dedicated-game-servers
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+    timeout: 15m
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # Server identity
+    name: factorio
+
+    # Factorio Docker image
+    image:
+      repository: factoriotools/factorio
+      tag: "stable"
+      pullPolicy: IfNotPresent
+
+    # Resource allocation
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: "1000m"
+      limits:
+        memory: "4Gi"
+        cpu: "2000m"
+
+    # Persistent storage for saves and mods
+    persistence:
+      enabled: true
+      storageClass: "nfs-client"
+      size: "50Gi"
+      mountPath: "/factorio"
+
+    # Network configuration (NodePort for home cluster access)
+    service:
+      type: NodePort
+      ports:
+        - name: game
+          port: 34197
+          nodePort: 30197
+          protocol: UDP
+        - name: rcon
+          port: 27015
+          nodePort: 30015
+          protocol: TCP
+
+    # Environment variables
+    env:
+      - name: UPDATE_MODS_ON_START
+        value: "false"
+      - name: SAVE_NAME
+        value: "save1"
+      - name: GENERATE_NEW_SAVE
+        value: "false"
+
+    # Factorio server settings (server-settings.json)
+    gameConfig:
+      enabled: true
+      mountPath: "/factorio/config"
+      files:
+        server-settings.json: |
+          {
+            "name": "Hancock Factorio",
+            "description": "A Factorio server running on Kubernetes",
+            "tags": ["game", "tags"],
+            "max_players": 10,
+            "visibility": {
+              "public": false,
+              "lan": true
+            },
+            "username": "",
+            "password": "",
+            "token": "",
+            "game_password": "",
+            "require_user_verification": false,
+            "max_upload_in_kilobytes_per_second": 0,
+            "max_upload_slots": 5,
+            "minimum_latency_in_ticks": 0,
+            "ignore_player_limit_for_returning_players": false,
+            "allow_commands": "admins-only",
+            "autosave_interval": 10,
+            "autosave_slots": 5,
+            "afk_autokick_interval": 0,
+            "auto_pause": true,
+            "only_admins_can_pause_the_game": true,
+            "autosave_only_on_server": true,
+            "non_blocking_saving": false,
+            "minimum_segment_size": 25,
+            "minimum_segment_size_peer_count": 20,
+            "maximum_segment_size": 100,
+            "maximum_segment_size_peer_count": 10
+          }
+
+    # Security context
+    securityContext:
+      fsGroup: 845
+      runAsUser: 845
+      runAsNonRoot: true
+
+    # Optional: Pin to specific node if needed
+    nodeSelector: {}
+    tolerations: []

--- a/kubernetes/apps/games/factorio/app/helmrepository.yaml
+++ b/kubernetes/apps/games/factorio/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: dedicated-game-servers
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://craightonh.github.io/dedicated-game-servers/

--- a/kubernetes/apps/games/factorio/app/kustomization.yaml
+++ b/kubernetes/apps/games/factorio/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: games
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/games/factorio/ks.yaml
+++ b/kubernetes/apps/games/factorio/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app factorio
+  namespace: flux-system
+spec:
+  targetNamespace: games
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/games/factorio/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./boilerr/ks.yaml
+  - ./factorio/ks.yaml
   - ./web-games/ks.yaml
   - ./satisfactory/ks.yaml
   # - ./icarus/ks.yaml


### PR DESCRIPTION
## Summary
Deploys a Factorio dedicated server using the newly published `dedicated-game-servers` Helm chart.

## Configuration
- **Chart**: `game-server` v1.0.1 from https://craightonh.github.io/dedicated-game-servers/
- **Storage**: 50GB NFS-backed PVC (`nfs-client` storage class)
- **Server Name**: Hancock Factorio
- **Visibility**: LAN-only (not public)
- **Resources**:
  - Requests: 2Gi RAM, 1 CPU
  - Limits: 4Gi RAM, 2 CPU

## Network Ports
- **Game**: UDP 30197 (maps to 34197 in-game)
- **RCON**: TCP 30015 (maps to 27015 in-game)

No conflicts with existing games:
- Icarus: 32777, 32778
- Satisfactory: 30777, 30888

## Features
- Auto-pause when no players
- Auto-save every 10 minutes (5 rotating saves)
- Admins-only command access
- fsGroup=845, runAsUser=845 (non-root)

## After Merge
Flux will automatically:
1. Add the Helm repository source
2. Deploy the Factorio server
3. Create the 50GB PVC
4. Expose the NodePort service

Ready to play once deployed! 🏭