### PR TITLE
fix(factorio): Switch to rootless image to resolve permission issues

### DIFF
--- a/kubernetes/apps/games/factorio/app/helmrelease.yaml
+++ b/kubernetes/apps/games/factorio/app/helmrelease.yaml
@@ -26,10 +26,10 @@ spec:
     # Server identity
     name: factorio
 
-    # Factorio Docker image
+    # Factorio Docker image (rootless variant avoids NFS permission issues)
     image:
       repository: factoriotools/factorio
-      tag: "stable"
+      tag: "stable-rootless"
       pullPolicy: IfNotPresent
 
     # Resource allocation
@@ -108,10 +108,10 @@ spec:
             "maximum_segment_size_peer_count": 10
           }
 
-    # Security context
+    # Security context (rootless image runs as UID 1000)
     securityContext:
-      fsGroup: 845
-      runAsUser: 845
+      fsGroup: 1000
+      runAsUser: 1000
       runAsNonRoot: true
 
     # Optional: Pin to specific node if needed


### PR DESCRIPTION
## Problem
Factorio pod is in CrashLoopBackOff with permission denied errors:
```
/docker-entrypoint.sh: line 21: /factorio/config/rconpw: Permission denied
```

## Root Cause
NFS volumes don't properly respect `fsGroup`, leaving the mounted directory inaccessible to the non-root factorio user (UID 845).

## Solution
Switch to the **rootless Factorio image** (`stable-rootless`), which is the [official recommended solution](https://github.com/factoriotools/factorio-docker/blob/master/PERMISSION_ISSUES_GUIDE.md):
- Runs as UID 1000 instead of 845
- Avoids NFS permission issues entirely
- No init containers or permission fixes needed

## Changes
- Update image tag from `stable` to `stable-rootless`
- Update securityContext to use UID 1000

## After Merge
Flux will:
1. Pull the new rootless image
2. Recreate the pod with UID 1000
3. Server should start successfully without permission errors

Fixes the CrashLoopBackOff issue reported earlier. 🏭