### PR TITLE
fix(factorio): Add init container to fix NFS permissions

### DIFF
--- a/kubernetes/apps/games/factorio/app/helmrelease.yaml
+++ b/kubernetes/apps/games/factorio/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: game-server
-      version: "1.0.1"
+      version: "1.0.2"
       sourceRef:
         kind: HelmRepository
         name: dedicated-game-servers
@@ -113,6 +113,31 @@ spec:
       fsGroup: 1000
       runAsUser: 1000
       runAsNonRoot: true
+
+    # Init container to fix NFS permissions for rootless image
+    # Needed because existing PVC was created with UID 845 ownership
+    initContainers:
+      - name: fix-permissions
+        image: busybox:latest
+        command:
+          - sh
+          - -c
+          - |
+            echo "Creating Factorio directory structure..."
+            mkdir -p /factorio/saves
+            mkdir -p /factorio/config
+            mkdir -p /factorio/mods
+            mkdir -p /factorio/scenarios
+            mkdir -p /factorio/script-output
+            echo "Fixing permissions on /factorio..."
+            chown -R 1000:1000 /factorio
+            chmod -R 775 /factorio
+            echo "Permissions fixed!"
+        volumeMounts:
+          - name: data
+            mountPath: /factorio
+        securityContext:
+          runAsUser: 0  # Run as root to fix permissions
 
     # Optional: Pin to specific node if needed
     nodeSelector: {}


### PR DESCRIPTION
## Problem
Previous PR #26 was merged before the init container changes were pushed, so those changes never made it to main. Factorio pod is still crashing with permission denied errors.

## Solution
This PR adds the init container that was intended for PR #26:
- Upgrades to chart v1.0.2 (which adds initContainers support)
- Adds init container that:
  - Creates Factorio directory structure (saves, config, mods, scenarios, script-output)
  - Fixes ownership: `chown -R 1000:1000 /factorio`
  - Fixes permissions: `chmod -R 775 /factorio`

## Why This Works
- Existing PVC has UID 845 ownership from first deployment
- Rootless image runs as UID 1000 and can't write
- Init container runs as root, fixes ownership, then rootless container can write successfully

## After Merge
Pod should restart with init container → fix permissions → rootless Factorio starts successfully 🏭