### PR TITLE
fix(factorio): Upgrade to chart v1.0.3 with separate security contexts

### DIFF
--- a/kubernetes/apps/games/factorio/app/helmrelease.yaml
+++ b/kubernetes/apps/games/factorio/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: game-server
-      version: "1.0.2"
+      version: "1.0.3"
       sourceRef:
         kind: HelmRepository
         name: dedicated-game-servers
@@ -108,11 +108,15 @@ spec:
             "maximum_segment_size_peer_count": 10
           }
 
-    # Security context (rootless image runs as UID 1000)
-    securityContext:
+    # Pod-level security context (no runAsNonRoot to allow init container)
+    podSecurityContext:
       fsGroup: 1000
+
+    # Container-level security context  
+    containerSecurityContext:
       runAsUser: 1000
       runAsNonRoot: true
+      allowPrivilegeEscalation: false
 
     # Init container to fix NFS permissions for rootless image
     # Needed because existing PVC was created with UID 845 ownership


### PR DESCRIPTION
## Problem
Pod is stuck in `Init:CreateContainerConfigError` with error:
```
container's runAsUser breaks non-root policy
```

The init container needs to run as root (UID 0) to fix NFS permissions, but the pod-level `securityContext` has `runAsNonRoot: true`, which blocks all containers (including init containers) from running as root.

## Solution
Upgrade to chart v1.0.3 which separates pod and container security contexts:
- **podSecurityContext**: Pod-level settings (fsGroup only, no runAsNonRoot)
- **containerSecurityContext**: Container-level settings (runAsUser, runAsNonRoot)

## Changes
- Upgrade chart from v1.0.2 → v1.0.3
- Change `securityContext` → `podSecurityContext` + `containerSecurityContext`
- Remove `runAsNonRoot` from pod level, apply only to main container

## Result
- ✅ Init container can run as root (UID 0) to fix permissions
- ✅ Main container runs as non-root (UID 1000) for security
- ✅ Both can coexist safely in the same pod

## Dependencies
- Requires dedicated-game-servers PR #6 to be merged first

After both PRs merge, Factorio should finally start! 🏭