### PR TITLE
feat(factorio): Update to use new dedicated factorio chart

### DIFF
--- a/kubernetes/apps/games/factorio/app/helmrelease.yaml
+++ b/kubernetes/apps/games/factorio/app/helmrelease.yaml
@@ -8,8 +8,8 @@ spec:
   interval: 30m
   chart:
     spec:
-      chart: game-server
-      version: "1.0.3"
+      chart: factorio
+      version: "2026.01.1"
       sourceRef:
         kind: HelmRepository
         name: dedicated-game-servers
@@ -70,45 +70,43 @@ spec:
       - name: GENERATE_NEW_SAVE
         value: "false"
 
-    # Factorio server settings (server-settings.json)
+    # Factorio server settings (camelCase, converted to snake_case automatically)
     gameConfig:
       enabled: true
       mountPath: "/factorio/config"
-      files:
-        server-settings.json: |
-          {
-            "name": "Hancock Factorio",
-            "description": "A Factorio server running on Kubernetes",
-            "tags": ["game", "tags"],
-            "max_players": 10,
-            "visibility": {
-              "public": false,
-              "lan": true
-            },
-            "username": "",
-            "password": "",
-            "token": "",
-            "game_password": "",
-            "require_user_verification": false,
-            "max_upload_in_kilobytes_per_second": 0,
-            "max_upload_slots": 5,
-            "minimum_latency_in_ticks": 0,
-            "ignore_player_limit_for_returning_players": false,
-            "allow_commands": "admins-only",
-            "autosave_interval": 10,
-            "autosave_slots": 5,
-            "afk_autokick_interval": 0,
-            "auto_pause": true,
-            "only_admins_can_pause_the_game": true,
-            "autosave_only_on_server": true,
-            "non_blocking_saving": false,
-            "minimum_segment_size": 25,
-            "minimum_segment_size_peer_count": 20,
-            "maximum_segment_size": 100,
-            "maximum_segment_size_peer_count": 10
-          }
+      serverSettings:
+        name: "Hancock Factorio"
+        description: "A Factorio server running on Kubernetes"
+        tags:
+          - game
+          - tags
+        maxPlayers: 10
+        visibility:
+          public: false
+          lan: true
+        username: ""
+        password: ""
+        token: ""
+        gamePassword: ""
+        requireUserVerification: false
+        maxUploadInKilobytesPerSecond: 0
+        maxUploadSlots: 5
+        minimumLatencyInTicks: 0
+        ignorePlayerLimitForReturningPlayers: false
+        allowCommands: "admins-only"
+        autosaveInterval: 10
+        autosaveSlots: 5
+        afkAutokickInterval: 0
+        autoPause: true
+        onlyAdminsCanPauseTheGame: true
+        autosaveOnlyOnServer: true
+        nonBlockingSaving: false
+        minimumSegmentSize: 25
+        minimumSegmentSizePeerCount: 20
+        maximumSegmentSize: 100
+        maximumSegmentSizePeerCount: 10
 
-    # Pod-level security context (no runAsNonRoot to allow init container)
+    # Pod-level security context
     podSecurityContext:
       fsGroup: 1000
 


### PR DESCRIPTION
## Summary

Updates the Factorio server to use the new dedicated `factorio` chart (v2026.01.1) from dedicated-game-servers instead of the old generic `game-server` chart.

## Changes

### Chart Update
- **Chart**: `game-server` → `factorio` (dedicated chart)
- **Version**: `1.0.3` → `2026.01.1`
- **Source**: Same HelmRepository (`dedicated-game-servers`)

### Configuration Refactor
**Before** (old JSON format):
```yaml
gameConfig:
  files:
    server-settings.json: |
      {
        "name": "Hancock Factorio",
        "max_players": 10,
        "auto_pause": true,
        ...
      }
```

**After** (new camelCase YAML):
```yaml
gameConfig:
  serverSettings:
    name: "Hancock Factorio"
    maxPlayers: 10
    autoPause: true
```

## Benefits

1. **User-friendly**: YAML dict instead of JSON string
2. **Easy overrides**: Change single settings without editing entire JSON
3. **Type safety**: Helm validates structure
4. **Automatic conversion**: camelCase → snake_case for Factorio
5. **Latest features**: Init container, test validation, improved templates

## What's Preserved

- ✅ Server name: "Hancock Factorio"
- ✅ Max players: 10
- ✅ Private server (LAN only)
- ✅ All existing settings
- ✅ Init container for NFS permissions
- ✅ Same NodePorts (30197, 30015)
- ✅ Same storage/resources

## Testing

The new chart has been tested with:
- Helm lint validation ✅
- Deployment test in kind cluster ✅
- Startup message detection (`Hosting game at IP ADDR`) ✅
- Config file JSON validation ✅

## Deployment

Flux will:
1. Detect HelmRelease change
2. Pull `factorio` chart v2026.01.1 from GitHub Pages
3. Upgrade in-place (same PVC, same settings)
4. Server will restart with identical configuration