### PR TITLE
fix(renovate): Change schedule from weekends to any time

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
   "suppressNotifications": ["prEditedNotification", "prIgnoreNotification"],
   "rebaseWhen": "conflicted",
-  "schedule": ["every weekend"],
+  "schedule": ["at any time"],
   "ignorePaths": ["**/*.sops.*"],
   "flux": {
     "fileMatch": ["(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$"]


### PR DESCRIPTION
## Problem
Renovate was configured to only run `every weekend`, which meant:
- No dependency updates during the week
- No Renovate PRs being created
- Dependency Dashboard never appeared

## Solution
Changed schedule from `every weekend` to `at any time` to allow Renovate to:
- Run whenever it detects updates
- Create PRs for outdated dependencies
- Maintain the Dependency Dashboard issue

## Testing
After merge, Renovate should:
1. Create a Dependency Dashboard issue (if not exists)
2. Start scanning for outdated dependencies
3. Create PRs for available updates

## Notes
Renovate GitHub App is already installed and has access to this repo - the schedule was the only blocker.